### PR TITLE
Add doas, pkexec and kdesu as sudo alternatives

### DIFF
--- a/memo/D1665.bashrc2
+++ b/memo/D1665.bashrc2
@@ -101,7 +101,7 @@ if [[ $type == fix3 ]]; then
   if [[ ${BLE_VERSION-} ]]; then
     ble/function#advice after ble/widget/clear-screen '_ble_edit_lineno=0'
     _check_clear_command() {
-      local rex_eval_prefix='((eval|command|env|sudo)[[:space:]]+)?'
+      local rex_eval_prefix='((eval|command|env|sudo|doas|pkexec|kdesu)[[:space:]]+)?'
       local rex_clear_command='(tput[[:space:]]+)?(clear|reset)'
       local rex=$'(^|[\n;&|(])[[:space:]]*'$rex_eval_prefix$rex_clear_command'([ \t\n;&|)]|$)'
       [[ $BASH_COMMAND =~ $rex ]] && _ble_edit_lineno=0

--- a/src/edit.sh
+++ b/src/edit.sh
@@ -1826,7 +1826,7 @@ function ble/prompt/print-ruler.draw {
   [[ $bleopt_prompt_ruler ]] || return 0
 
   local command=$1 opts=$2 cols=$COLUMNS
-  local rex_eval_prefix='(([!{]|time|if|then|elif|while|until|do|exec|eval|command|env|nice|nohup|xargs|sudo)[[:space:]]+)?'
+  local rex_eval_prefix='(([!{]|time|if|then|elif|while|until|do|exec|eval|command|env|nice|nohup|xargs|sudo|doas|pkexec|kdesu)[[:space:]]+)?'
   local rex_clear_command='(tput[[:space:]]+)?(clear|reset)'
   local rex=$'(^|[\n;&|(])[[:space:]]*'$rex_eval_prefix$rex_clear_command'([ \t\n;&|)]|$)'
   [[ $command =~ $rex ]] && return 0


### PR DESCRIPTION
These three have the same functionalities as sudo does, so they should be treated equally. For example, currently completion works for commands after sudo but not doas.

I'm not pretty sure if the changes are complete though.