### PR TITLE
Sanity check strict <, -- to end opts to kill

### DIFF
--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -3,6 +3,10 @@
 
 2023-04-03... (`#D2030`...) 1a5c451c...
 
+## Fixes
+
+- util (`conditional-sync`): fix bugs when `pid=PID` is specified (contributed by bkerin) `#D2031` xxxxxxxx
+
 <!---------------------------------------------------------------------------->
 # ble-0.4.0-devel3
 

--- a/lib/test-util.sh
+++ b/lib/test-util.sh
@@ -1687,18 +1687,25 @@ fi
 (
   time=0
   ble/function#push ble/util/msleep '((time+=$1));echo $time'
-  ble/test "ble/util/conditional-sync 'sleep 10' '((time<1000))' 100" \
+  ble/test "ble/util/conditional-sync 'ble/bin/sleep 10' '((time<1000))' 100" \
            stdout={1..10}00
-  ble/test "ble/util/conditional-sync 'sleep 10' '((time<1000))' 100 progressive-weight" \
+  ble/test "ble/util/conditional-sync 'ble/bin/sleep 10' '((time<1000))' 100 progressive-weight" \
            stdout={1,3,7,15,31,63,{1..10}27}
-  ble/test "ble/util/conditional-sync 'sleep 10' '((time<1000))' 100 timeout=10" stdout=10 exit=142
-  ble/test "ble/util/conditional-sync 'sleep 10' '((time<1000))' 100 timeout=0" stdout= exit=142
-  sleep 10 & pid1=$!
-  ble/test "ble/util/conditional-sync 'sleep 10' '((time<1000))' 100 timeout=0:pid=$pid1" stdout= exit=142
-  sleep 10 & pid2=$!
-  ble/test "ble/util/conditional-sync 'sleep 10' '((time<1000))' 100 timeout=-1:pid=$pid2" stdout= exit=142
-  set -m; sleep 10 & pid3=$!; set +m
-  ble/test "ble/util/conditional-sync 'sleep 10' '((time<1000))' 100 timeout=0:pid=-$pid3" stdout= exit=142
+  ble/test "ble/util/conditional-sync 'ble/bin/sleep 10' '((time<1000))' 100 timeout=10" stdout=10 exit=142
+  ble/test "ble/util/conditional-sync 'echo unexpected' '((time<1000))' 100 timeout=0" stdout= exit=142
+  ble/bin/sleep 10 & pid1=$!
+  ble/test "ble/util/conditional-sync 'echo unexpected' '((time<1000))' 100 timeout=0:pid=$pid1" stdout= exit=142
+  ble/bin/sleep 10 & pid2=$!
+  ble/test "ble/util/conditional-sync 'echo unexpected' '((time<1000))' 100 timeout=-1:pid=$pid2" stdout= exit=142
+  set -m; ble/bin/sleep 10 & pid3=$!; set +m
+  ble/test "ble/util/conditional-sync 'echo unexpected' '((time<1000))' 100 timeout=0:pid=-$pid3" stdout= exit=142
+
+  # wait for the signal processing for a short moment
+  if [[ $OSTYPE == cygwin* || $OSTYPE == msys* ]]; then
+    ble/bin/sleep 0.20
+  else
+    ble/bin/sleep 0.02
+  fi
   ble/test 'kill -0 "$pid1"' exit=1
   ble/test 'kill -0 "$pid2"' exit=1
   ble/test 'kill -0 "$pid3"' exit=1

--- a/lib/test-util.sh
+++ b/lib/test-util.sh
@@ -1691,14 +1691,14 @@ fi
            stdout={1..10}00
   ble/test "ble/util/conditional-sync 'ble/bin/sleep 10' '((time<1000))' 100 progressive-weight" \
            stdout={1,3,7,15,31,63,{1..10}27}
-  ble/test "ble/util/conditional-sync 'ble/bin/sleep 10' '((time<1000))' 100 timeout=10" stdout=10 exit=142
-  ble/test "ble/util/conditional-sync 'echo unexpected' '((time<1000))' 100 timeout=0" stdout= exit=142
+  ble/test "ble/util/conditional-sync 'ble/bin/sleep 10' 'true' 100 timeout=10" stdout=10 exit=142
+  ble/test "ble/util/conditional-sync 'echo unexpected' 'true' 100 timeout=0" stdout= exit=142
   ble/bin/sleep 10 & pid1=$!
-  ble/test "ble/util/conditional-sync 'echo unexpected' '((time<1000))' 100 timeout=0:pid=$pid1" stdout= exit=142
+  ble/test "ble/util/conditional-sync 'echo unexpected' 'true' 100 timeout=0:pid=$pid1" stdout= exit=142
   ble/bin/sleep 10 & pid2=$!
-  ble/test "ble/util/conditional-sync 'echo unexpected' '((time<1000))' 100 timeout=-1:pid=$pid2" stdout= exit=142
+  ble/test "ble/util/conditional-sync 'echo unexpected' 'true' 100 timeout=-1:pid=$pid2" stdout= exit=142
   set -m; ble/bin/sleep 10 & pid3=$!; set +m
-  ble/test "ble/util/conditional-sync 'echo unexpected' '((time<1000))' 100 timeout=0:pid=-$pid3" stdout= exit=142
+  ble/test "ble/util/conditional-sync 'echo unexpected' 'true' 100 timeout=0:pid=-$pid3" stdout= exit=142
 
   # wait for the signal processing for a short moment
   if [[ $OSTYPE == cygwin* || $OSTYPE == msys* ]]; then

--- a/lib/test-util.sh
+++ b/lib/test-util.sh
@@ -2,7 +2,7 @@
 
 ble-import lib/core-test
 
-ble/test/start-section 'ble/util' 1226
+ble/test/start-section 'ble/util' 1234
 
 # bleopt
 
@@ -1691,6 +1691,17 @@ fi
            stdout={1..10}00
   ble/test "ble/util/conditional-sync 'sleep 10' '((time<1000))' 100 progressive-weight" \
            stdout={1,3,7,15,31,63,{1..10}27}
+  ble/test "ble/util/conditional-sync 'sleep 10' '((time<1000))' 100 timeout=10" stdout=10 exit=142
+  ble/test "ble/util/conditional-sync 'sleep 10' '((time<1000))' 100 timeout=0" stdout= exit=142
+  sleep 10 & pid1=$!
+  ble/test "ble/util/conditional-sync 'sleep 10' '((time<1000))' 100 timeout=0:pid=$pid1" stdout= exit=142
+  sleep 10 & pid2=$!
+  ble/test "ble/util/conditional-sync 'sleep 10' '((time<1000))' 100 timeout=-1:pid=$pid2" stdout= exit=142
+  set -m; sleep 10 & pid3=$!; set +m
+  ble/test "ble/util/conditional-sync 'sleep 10' '((time<1000))' 100 timeout=0:pid=-$pid3" stdout= exit=142
+  ble/test 'kill -0 "$pid1"' exit=1
+  ble/test 'kill -0 "$pid2"' exit=1
+  ble/test 'kill -0 "$pid3"' exit=1
   ble/function#pop ble/util/msleep
 )
 

--- a/note.txt
+++ b/note.txt
@@ -6840,3 +6840,19 @@ bash_tips
 *******************************************************************************
     Done (実装ログ)
 -------------------------------------------------------------------------------
+
+2023-04-08
+
+  * util (conditoinal-sync): opts に指定した pid=PID/-PGID が動かない (contributed by bkerin) [#D2031]
+    https://github.com/akinomyoga/ble.sh/discussions/309#discussioncomment-5556211
+    https://github.com/akinomyoga/ble.sh/pull/313
+
+    これは conditional-sync を弄って外部から pid を指定できる様にした時のバグ
+    https://github.com/akinomyoga/ble.sh/commit/8d623c1927c2c4e381bd484bcc51def3213890f6
+
+    先ず PGID を指定すると kill がシグナルと勘違いして動かない。次に timeout=0
+    を一緒に指定すると既存の pid があっても kill を試行せずにそのまま終了してし
+    まう。
+
+    提案では負の時にだけそのまま終了する様になっていたが、負であっても pid が指
+    定されていればちゃんと kill して終了する様にしたい。調整する。

--- a/note.txt
+++ b/note.txt
@@ -6856,3 +6856,20 @@ bash_tips
 
     提案では負の時にだけそのまま終了する様になっていたが、負であっても pid が指
     定されていればちゃんと kill して終了する様にしたい。調整する。
+
+    ----
+
+    2023-04-09 GitHub CI で Windows が失敗している。手元の cygwin で試すと何故
+    か sleep 10 を kill しても全く効果がない。然し、プロンプトを跨いで kill を
+    実行するとちゃんとその場で動く。色々実験した結果 subshell を少なくとも一回
+    以上立ち上げた後だと kill が効く様である。これは kill -- でも kill -9 でも
+    同様である。
+
+    $ tkill() { kill -9 "$p"; ((count++)); sleep 0.01; }
+    $ sleep 10 & p=$!; count=0
+    $ (true)    # <-- これがあるかないかで必要な kill 回数が変わる
+    $ tkill; while kill -0 "$p"; do tkill; done; date +'%s.%N':$count
+
+    然し、CI test に関しては単に delay を入れるだけで解決してしまった。然し、場
+    合によってはやはり kill できないという状況になると行けないので念の為
+    Windows では subshell を一つ作る事にする。

--- a/src/util.sh
+++ b/src/util.sh
@@ -3671,7 +3671,7 @@ function ble/util/conditional-sync/.kill {
   if [[ :$__ble_opts: == *:SIGKILL:* ]]; then
     builtin kill -9 "${kill_pids[@]}" &>/dev/null
   else
-    builtin kill "${kill_pids[@]}" &>/dev/null
+    builtin kill -- "${kill_pids[@]}" &>/dev/null
   fi
 } &>/dev/null
 
@@ -3734,7 +3734,7 @@ function ble/util/conditional-sync {
     local __ble_weight_max=$__ble_weight __ble_weight=1
 
   local sync_elapsed=0
-  if [[ $__ble_timeout ]] && ((__ble_timeout<=0)); then return 142; fi
+  if [[ $__ble_timeout ]] && ((__ble_timeout<0)); then return 142; fi
   builtin eval -- "$__ble_continue" || return 148
   (
     local __ble_pid=

--- a/src/util.sh
+++ b/src/util.sh
@@ -3669,6 +3669,12 @@ function ble/util/conditional-sync/.kill {
     kill_pids=("$__ble_pid")
   fi
 
+  # Note #D2031: In Cygwin/MSYS2 (Windows), we somehow need to fork at least
+  # one process before `kill` to make sure it works.
+  if [[ $OSTYPE == cygwin* || $OSTYPE == msys* ]]; then
+    (ble/util/setexit 0)
+  fi
+
   if [[ :$__ble_opts: == *:SIGKILL:* ]]; then
     builtin kill -9 "${kill_pids[@]}" &>/dev/null
   else


### PR DESCRIPTION
kill -- is needed or the PGID (negative number) is interpreted as -sigspec option when no -sigspec has already been given (e.g. when -9 is already given negative pid works without --).

The other change is on what looks like a sanity check on __ble_timeout.  Negative __ble_timeout obviously doesn't make sense but now at least 0 is allowed (but I didn't look carefully to see if the other code makes sense with 0, though it seems to work).