### PR TITLE
Rename widget "vi-command/edit-and-execute-line" to "vi-command/edit-and-execute-command" (correct name)

### DIFF
--- a/lib/core-decode.vi_nmap-rlfunc.txt
+++ b/lib/core-decode.vi_nmap-rlfunc.txt
@@ -39,7 +39,7 @@ dump-functions                    vi_nmap/@adjust readline-dump-functions
 dump-macros                       vi_nmap/@adjust readline-dump-macros
 dump-variables                    vi_nmap/@adjust readline-dump-variables
 dynamic-complete-history          -
-edit-and-execute-command          vi-command/edit-and-execute-line
+edit-and-execute-command          vi-command/edit-and-execute-command
 emacs-editing-mode                emacs-editing-mode
 end-kbd-macro                     end-keyboard-macro
 end-of-history                    vi-command/history-end


### PR DESCRIPTION
This PR edits file `lib/core-decode.vi_nmap-rlfunc.txt:42` by changing `vi-command/edit-and-execute-line` to `vi-command/edit-and-execute-command` since it seems to be the correct name.  

With the wrong name, when starting ble.sh with bash in vi mode, I got this error:  
> ble-bind: Unknown widget `vi-command/edit-and-execute-line'.

After the rename, no more error.

Here are my versions if debug is needed:
```bash
$ bash --version
GNU bash, version 5.2.2(1)-release (x86_64-redhat-linux-gnu)
```
```
$ ble --version
ble.sh (Bash Line Editor), version 0.4.0-devel4+ef8272a
```
```
$ dnf info --installed readline
Installed Packages
Name         : readline
Version      : 8.1
Release      : 6.fc36
Architecture : x86_64
Size         : 482 k
Source       : readline-8.1-6.fc36.src.rpm
Repository   : @System
From repo    : anaconda
Summary      : A library for editing typed command lines
URL          : https://tiswww.case.edu/php/chet/readline/rltop.html
```