### PR TITLE
fix: change to correct comparison operator

### DIFF
--- a/src/util.sh
+++ b/src/util.sh
@@ -1294,7 +1294,7 @@ if ((_ble_bash>=40400)); then
 else
   function ble/string#quote-words {
     local q=\' Q="'\''" IFS=$_ble_term_IFS
-    if (($#===1)); then
+    if (($#==1)); then
       ret=("${1//$q/$Q}")    # WA for #D2352
       ret=("${ret[0]/%/$q}") # WA for #D2352 (disable=#D1738)
     else


### PR DESCRIPTION
Fixes a problem in which the following error message would appear each time a character was entered at the prompt

```
bash: ((: 1===1: syntax error: operand expected (error token is "=1")
```

commit 8bea90d17f6cdcde7198f5f62058dcca7f0c20f1 to have a problem.
