### PR TITLE
util (ble/util/load-standard-builtin): actually load from $loadable_path

### DIFF
--- a/src/util.sh
+++ b/src/util.sh
@@ -3022,7 +3022,7 @@ function ble/util/load-standard-builtin {
            { [[ ! $2 ]] || builtin eval -- "$2"; }
        ) &>/dev/null
     then
-      enable -f "$bash_prefix/lib/bash/$1" "$1"
+      enable -f "$loadable_path/$1" "$1"
       return 0
     fi
   done


### PR DESCRIPTION
I'm pretty sure the way this is currently written all possible `${loadable_paths[@]}` are checked for a valid builtin... only to then completely ignore the checks and load from `$bash_prefix/lib/bash/`. It should probably load from the just validated `$loadable_path`.

Noticed this because on my system builtins are in `/usr/lib64/bash/` so the checks passed for that directory.
`ble.sh` then "loaded" the wrong builtins which resulted in every call to them printing `bash: builtin: xxxxx: not a shell builtin` to the console.