### PR TITLE
Move awk instantiation after loading util functions.

### DIFF
--- a/src/util.sh
+++ b/src/util.sh
@@ -2501,9 +2501,6 @@ else
 fi
 
 
-# ble/bin/awk の初期化に ble/util/assign を使うので
-ble/bin/awk/.instantiate
-
 #
 # functions
 #
@@ -2527,6 +2524,9 @@ else
     [[ $type == function ]]
   }
 fi
+
+# ble/bin/awk の初期化に ble/util/assign を使うので
+ble/bin/awk/.instantiate
 
 ## @fn ble/function#getdef function
 ##   @var[out] def


### PR DESCRIPTION
Move awk instantiation after ble/is-function is defined, as it needs/uses it. Currently the function is referenced before it is defined, which leads to an error message when starting ble.sh.