### PR TITLE
syntax (completion-context): fix an infinite loop with three or more nested brace contexts

### DIFF
--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -201,6 +201,7 @@
 - cmdspec (`declare/chroma`): fix a bug of evaluating global variable `d` (reported by LeonardoMor) `#D2387` 57ad2bf5
 - util (`ble/function#advice`): fix `-f` doing the opposite (reported by Funeralsawa) `#D2401` 801cc1c8
 - make: fix a race condition (reported by sanvila) `#2406` xxxxxxxx
+- syntax (completion-context): fix an infinite loop caused by nested braces (fixed by dlyongemallo) `#D2407` xxxxxxxx
 
 ## Compatibility
 

--- a/lib/core-syntax.sh
+++ b/lib/core-syntax.sh
@@ -6101,7 +6101,7 @@ function ble/syntax/completion-context/prefix:brace {
     ble/string#split-words nest "$nest"
     ctx1=${nest[0]}
     ((ctx1==CTX_BRACE1||ctx1==CTX_BRACE2)) || break
-    inest1=${nest[3]}
+    inest1=$((nest[3]<0?nest[3]:inest1-nest[3]))
     ((inest1>=0)) || return 1
   done
 

--- a/lib/test-syntax.sh
+++ b/lib/test-syntax.sh
@@ -50,18 +50,20 @@ ble/test/start-section 'ble/syntax' 30
     ble/syntax/initialize-vars
     ble/syntax/parse "$input" ''
     sources=()
-    ble/syntax/completion-context/generate "$input" "${#input}"
-    ret=${sources[*]}
+    ble/util/conditional-sync '
+      ble/syntax/completion-context/generate "$input" "${#input}"
+      echo "${sources[*]}"
+    ' true '' timeout=100
   }
   func=ble/test:syntax/completion-context
-  ble/test "$func '{'           " ret='command 0'
-  ble/test "$func '{{'          " ret='argument 0'
-  ble/test "$func '{{{'         " ret='argument 0'
-  ble/test "$func '{{{{'        " ret='argument 0'
-  ble/test "$func 'a{b,'        " ret='argument 0'
-  ble/test "$func 'a{{b,'       " ret='argument 0'
-  ble/test "$func 'a{{{b,'      " ret='argument 0'
-  ble/test "$func 'a{b,{c,{d,'  " ret='argument 0'
+  ble/test "$func '{'           " exit=0 stdout='command 0'
+  ble/test "$func '{{'          " exit=0 stdout='argument 0'
+  ble/test "$func '{{{'         " exit=0 stdout='argument 0'
+  ble/test "$func '{{{{'        " exit=0 stdout='argument 0'
+  ble/test "$func 'a{b,'        " exit=0 stdout='argument 0'
+  ble/test "$func 'a{{b,'       " exit=0 stdout='argument 0'
+  ble/test "$func 'a{{{b,'      " exit=0 stdout='argument 0'
+  ble/test "$func 'a{b,{c,{d,'  " exit=0 stdout='argument 0'
 )
 
 ble/test/end-section

--- a/lib/test-syntax.sh
+++ b/lib/test-syntax.sh
@@ -3,7 +3,7 @@
 ble-import lib/core-syntax
 ble-import lib/core-test
 
-ble/test/start-section 'ble/syntax' 22
+ble/test/start-section 'ble/syntax' 30
 
 (
   func=ble/syntax:bash/simple-word/evaluate-last-brace-expansion
@@ -40,6 +40,28 @@ ble/test/start-section 'ble/syntax' 22
   ble/test "$func '~/a/b/c'            ; $collect" ret="~ ~/a ~/a/b ~/a/b/c >>> $HOME $HOME/a $HOME/a/b $HOME/a/b/c"
   ble/test "$func '~/a/b/c' / after-sep; $collect" ret="~/ ~/a/ ~/a/b/ ~/a/b/c >>> $HOME/ $HOME/a/ $HOME/a/b/ $HOME/a/b/c"
   ble/test "$func '/x/y/z' / after-sep ; $collect" ret="/ /x/ /x/y/ /x/y/z >>> / /x/ /x/y/ /x/y/z"
+)
+
+# Regression test for #698: nested brace contexts (e.g. "{{{") used to send
+# ble/syntax/completion-context/prefix:brace into an infinite loop.
+(
+  function ble/test:syntax/completion-context {
+    local input=$1
+    ble/syntax/initialize-vars
+    ble/syntax/parse "$input" ''
+    sources=()
+    ble/syntax/completion-context/generate "$input" "${#input}"
+    ret=${sources[*]}
+  }
+  func=ble/test:syntax/completion-context
+  ble/test "$func '{'           " ret='command 0'
+  ble/test "$func '{{'          " ret='argument 0'
+  ble/test "$func '{{{'         " ret='argument 0'
+  ble/test "$func '{{{{'        " ret='argument 0'
+  ble/test "$func 'a{b,'        " ret='argument 0'
+  ble/test "$func 'a{{b,'       " ret='argument 0'
+  ble/test "$func 'a{{{b,'      " ret='argument 0'
+  ble/test "$func 'a{b,{c,{d,'  " ret='argument 0'
 )
 
 ble/test/end-section

--- a/note.txt
+++ b/note.txt
@@ -8211,14 +8211,20 @@ bash_tips
 
 2026-05-28
 
-  * make: race condition (reported by sanvila) [#2406]
+  * completion-context: fix an infinite loop caused by nested braces (fixed by dlyongemallo) [#D2407]
+    https://github.com/akinomyoga/ble.sh/pull/699
+
+    これは確かにバグである。そして提出された修正は正しい。テストを修正して適用
+    する事にする。
+
+  * make: race condition (reported by sanvila) [#D2406]
     https://github.com/akinomyoga/ble.sh/issues/688
 
     * https://github.com/akinomyoga/ble.sh/issues/689 ほぼ同時期に類似の報告が
       あって色々調べていたが、これは既に修正済みの問題だった。なので、
       GitHub#688 の方で報告された修正だけで十分であるという結論になった。
 
-  * github: また actions/checkout のバージョンが上がっている [#2405]
+  * github: また actions/checkout のバージョンが上がっている [#D2405]
 
     更新しなければならない。
 

--- a/note.txt
+++ b/note.txt
@@ -8211,7 +8211,7 @@ bash_tips
 
 2026-05-28
 
-  * completion-context: fix an infinite loop caused by nested braces (fixed by dlyongemallo) [#D2407]
+  * syntax (completion-context): fix an infinite loop caused by nested braces (fixed by dlyongemallo) [#D2407]
     https://github.com/akinomyoga/ble.sh/pull/699
 
     これは確かにバグである。そして提出された修正は正しい。テストを修正して適用


### PR DESCRIPTION
`nest[3]` stores `nlen` (the length to the parent nest), not the parent's absolute index. Following the same pattern as `nest-pop`, convert it via `inest1-nest[3]`. Without this, every `_ble_syntax_nest[k]` for `k>=1` inside `{{{...}` has `nlen=1`, and the walk-outward loop becomes a fixed point at `inest1=1`.

Fixes #698.