### PR TITLE
history: fix duplicate entries after "history -n" with HISTTIMEFORMAT

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -140,6 +140,7 @@ outfiles += $(OUTDIR)/lib/test-edit.sh
 outfiles += $(OUTDIR)/lib/test-syntax.sh
 outfiles += $(OUTDIR)/lib/test-complete.sh
 outfiles += $(OUTDIR)/lib/test-keymap.vi.sh
+outfiles += $(OUTDIR)/lib/test-history.sh
 
 $(OUTDIR)/lib/%.sh: lib/%.sh | $(OUTDIR)/lib
 	$(CP) $< $@

--- a/ble.pp
+++ b/ble.pp
@@ -3208,7 +3208,7 @@ function ble/base/sub:test {
   ble-import lib/core-test
 
   if (($#==0)); then
-    set -- bash main util canvas decode edit syntax complete keymap.vi
+    set -- bash main util canvas decode edit syntax complete keymap.vi history
     local timestamp
     ble/util/strftime -v timestamp '%Y%m%d.%H%M%S'
     logfile=$_ble_base_cache/test.$timestamp.log

--- a/lib/test-history.sh
+++ b/lib/test-history.sh
@@ -1,0 +1,299 @@
+# source script for ble.sh interactive sessions -*- mode: sh; mode: sh-bash -*-
+
+ble-import lib/core-test
+
+ble/test/start-section 'ble/builtin/history' 41
+
+#------------------------------------------------------------------------------
+# helpers
+
+## @fn ble/test/history/write-file file count [ts] [first]
+##   Writes "count" entries "echo cmdN" (N starting at "first", default 1) to
+##   "file" in the HISTFILE format.  When "ts" is non-empty, every entry is
+##   preceded by a timestamp line as written by Bash with HISTTIMEFORMAT.
+function ble/test/history/write-file {
+  local file=$1 count=$2 ts=$3 first=${4:-1} i
+  {
+    for ((i=first;i<first+count;i++)); do
+      [[ $ts ]] && ble/util/print "#$((1700000000+i))"
+      ble/util/print "echo cmd$i"
+    done
+  } >| "$file"
+}
+## @fn ble/test/history/append-file file count [ts] [first]
+function ble/test/history/append-file {
+  local file=$1 count=$2 ts=$3 first=${4:-1} i
+  {
+    for ((i=first;i<first+count;i++)); do
+      [[ $ts ]] && ble/util/print "#$((1700000000+i))"
+      ble/util/print "echo cmd$i"
+    done
+  } >> "$file"
+}
+## @fn ble/test/history/load-file file
+##   Replaces the in-memory history with the content of "file", which is what
+##   Bash does with HISTFILE on startup.
+function ble/test/history/load-file {
+  builtin history -c
+  builtin history -r "$1"
+}
+## @fn ble/test/history/list
+##   Prints the commands in the in-memory history, one entry per line.
+function ble/test/history/list {
+  (HISTTIMEFORMAT=; builtin history) | ble/bin/awk '{ sub(/^ *[0-9]+\*? +/, ""); print; }'
+}
+## @fn ble/test/history/count
+##   Prints the number of lines of the in-memory history.
+function ble/test/history/count {
+  (HISTTIMEFORMAT=; builtin history) | ble/bin/awk 'END { print NR; }'
+}
+## @fn ble/test/history/.check-session-entries
+##   Checks whether entries added with "builtin history -s" are written by
+##   "builtin history -a" in this process.  This is how .initialize collects
+##   the entries added before ble.sh is loaded.  In non-interactive shells of
+##   old Bash versions, "history -s" does not count as a line of the session,
+##   so the tests that depend on it are skipped there.
+function ble/test/history/.check-session-entries {
+  (
+    builtin history -c
+    ble/test/history/enable-timestamps
+    builtin history -s 'echo probe'
+    builtin history -a probe.ini
+    [[ -s probe.ini ]]
+  )
+}
+## @fn ble/test/history/rskip file
+function ble/test/history/rskip {
+  local rskip; ble/builtin/history/.get-rskip "$1"
+  ble/util/print "$rskip"
+}
+## @fn ble/test/history/reset-state
+##   Clears the state of ble/builtin/history that persists in the runtime
+##   directory and in variables, so that a test starts from a clean slate.
+function ble/test/history/reset-state {
+  >| "$_ble_base_run/$$.history.new"
+  >| "$_ble_base_run/$$.history.app"
+  >| "$_ble_base_run/$$.history.ini"
+  ble/bin/rm -f "$_ble_base_run/$$.history.touch"
+  _ble_builtin_history_histnew_count=0
+  _ble_builtin_history_histapp_count=0
+  _ble_builtin_history_initialized=
+  _ble_builtin_history_wskip=0
+  _ble_builtin_history_prevmax=0
+}
+
+## @fn ble/test/history/enable-timestamps
+##   Makes Bash write and parse timestamp lines like in an interactive session
+##   with HISTTIMEFORMAT.  A real assignment is needed because a temporary
+##   assignment for a builtin does not take effect in non-interactive shells.
+##   Old versions of Bash set the history comment character only during the
+##   initialization of interactive shells, so assigning "histchars" (with its
+##   default value) is needed for "history -r" to recognize timestamp lines
+##   in the non-interactive test process.
+function ble/test/history/enable-timestamps {
+  HISTTIMEFORMAT='%s '
+  histchars='!^#'
+}
+
+## @fn ble/test/history/initialize-rskip nfile ngrow ts histsize [nsession]
+##   Simulates the situation in which ble/builtin/history/.initialize runs:
+##   Bash has read "nfile" entries from HISTFILE (with timestamp lines when "ts"
+##   is non-empty) under the specified HISTSIZE (empty for unlimited),
+##   "nsession" entries have been added in this session, and "ngrow" entries
+##   have been appended to HISTFILE by another session afterwards.  Prints the
+##   resulting rskip.  This function has to be called in a subshell.
+function ble/test/history/initialize-rskip {
+  local nfile=$1 ngrow=$2 ts=$3 histsize=$4 nsession=${5:-0}
+  ble/test/history/reset-state
+  HISTFILE=$PWD/histfile
+  { [[ $ts ]] || ((nsession)); } && ble/test/history/enable-timestamps
+  ble/test/history/write-file "$HISTFILE" "$nfile" "$ts"
+  if [[ $histsize ]]; then
+    HISTSIZE=$histsize
+  else
+    builtin unset -v HISTSIZE
+  fi
+  ble/test/history/load-file "$HISTFILE"
+  local i
+  for ((i=1;i<=nsession;i++)); do
+    builtin history -s "echo session$i"
+  done
+  ((ngrow)) && ble/test/history/append-file "$HISTFILE" "$ngrow" "$ts" "$((nfile+1))"
+  ble/builtin/history/.initialize
+  ble/test/history/rskip "$HISTFILE"
+}
+
+#------------------------------------------------------------------------------
+# ble/builtin/history/.count-entries
+#
+#   An entry is a line that does not start with "#" followed by a digit, which
+#   is exactly what Bash skips as a timestamp line when reading HISTFILE.
+
+(
+  ble/test/chdir || exit
+  ble/test/history/write-file plain 3
+  ble/test/history/write-file ts 3 ts
+  ble/test 'ble/builtin/history/.count-entries plain' ret=3
+  ble/test 'ble/builtin/history/.count-entries ts' ret=3
+  ble/util/print-lines '#1700000001' 'echo a' '#12ab junk' 'echo b' '#0' 'echo c' '#1 not a timestamp' 'echo d' >| odd
+  ble/test 'ble/builtin/history/.count-entries odd' ret=4 \
+           '# any "#<digit>..." line is a timestamp line for Bash'
+  ble/util/print-lines '#comment' 'echo a' '# 1' 'echo b' >| comments
+  ble/test 'ble/builtin/history/.count-entries comments' ret=4 \
+           '# "#" not followed by a digit is a command'
+  ble/test/rmdir
+)
+
+#------------------------------------------------------------------------------
+# ble/builtin/history/.is-HISTSIZE-reached
+
+(
+  ble/test '(builtin unset -v HISTSIZE; ble/builtin/history/.is-HISTSIZE-reached 1000000)' exit=1
+  ble/test '(HISTSIZE=; ble/builtin/history/.is-HISTSIZE-reached 1000000)' exit=1
+  ble/test '(HISTSIZE=abc; ble/builtin/history/.is-HISTSIZE-reached 1000000)' exit=1
+  ble/test '(HISTSIZE=5x; ble/builtin/history/.is-HISTSIZE-reached 1000000)' exit=1
+  ble/test '(HISTSIZE=" 5 "; ble/builtin/history/.is-HISTSIZE-reached 4)' exit=1
+  ble/test '(HISTSIZE=" 5 "; ble/builtin/history/.is-HISTSIZE-reached 5)' exit=0
+  ble/test '(HISTSIZE=+5; ble/builtin/history/.is-HISTSIZE-reached 6)' exit=0
+  if ((_ble_bash>=40300)); then
+    ble/test '(HISTSIZE=-1; ble/builtin/history/.is-HISTSIZE-reached 1000000)' exit=1 \
+             '# negative HISTSIZE is unlimited in Bash >= 4.3'
+  else
+    ble/test '(HISTSIZE=-1; ble/builtin/history/.is-HISTSIZE-reached 0)' exit=0 \
+             '# negative HISTSIZE is a limit in Bash <= 4.2'
+  fi
+)
+
+#------------------------------------------------------------------------------
+# ble/builtin/history/.read
+#
+#   "skip" and rskip count entries, not lines.
+
+(
+  ble/test/chdir || exit
+  ble/test/history/reset-state
+  ble/test/history/enable-timestamps
+  ble/test/history/write-file file 3 ts
+  builtin history -c
+
+  ble/test 'ble/builtin/history/.read file 1; ble/test/history/list' \
+           stdout=$'echo cmd2\necho cmd3' \
+           '# skip counts entries (a timestamped entry has two lines)'
+  ble/test 'ble/test/history/rskip file' stdout=3 \
+           '# rskip is the number of entries in the file'
+  ble/test 'ble/util/print "$_ble_builtin_history_wskip"' stdout=2 \
+           '# wskip follows the last history number'
+
+  # fetch: the new entries are kept in the "new" file until the next read
+  builtin history -c
+  ble/test/history/reset-state
+  ble/test 'ble/builtin/history/.read file 1 fetch; ble/test/history/count' stdout=0
+  ble/test 'ble/util/print "$_ble_builtin_history_histnew_count"' stdout=2 \
+           '# fetched entries are counted in entries'
+  ble/test 'ble/test/history/rskip file' stdout=3
+  ble/test 'ble/builtin/history/.read file 3; ble/test/history/list' \
+           stdout=$'echo cmd2\necho cmd3' \
+           '# a later read loads the fetched entries'
+  ble/test 'ble/util/print "$_ble_builtin_history_histnew_count"' stdout=0
+
+  ble/test/rmdir
+)
+
+#------------------------------------------------------------------------------
+# ble/builtin/history/.write
+#
+#   rskip is advanced by the number of entries written (not lines), and set
+#   to the number of entries when the file is rewritten (history -w).
+
+(
+  ble/test/chdir || exit
+  ble/test/history/reset-state
+  ble/test/history/enable-timestamps
+  ble/test/history/write-file seed 3 ts
+  ble/test/history/load-file seed
+  >| out
+  ble/builtin/history/.set-rskip out 10
+
+  ble/test 'ble/builtin/history/.write out 0 append; ble/test/history/rskip out' stdout=13 \
+           '# append: rskip advances by 3 entries although 6 lines were written'
+  ble/test 'ble/builtin/history/.count-entries out' ret=3
+  ble/test 'ble/bin/awk "END { print NR; }" out' stdout=6
+  ble/test 'ble/util/print "$_ble_builtin_history_wskip"' stdout=3
+
+  ble/test 'ble/builtin/history/.write out 0; ble/test/history/rskip out' stdout=3 \
+           '# rewrite (history -w): rskip is the number of entries in the file'
+  ble/test 'ble/bin/awk "END { print NR; }" out' stdout=6
+
+  # a multi-line entry is written as one "eval -- $'"'"'...'"'"'" line and counts as one entry
+  builtin history -s $'echo multi\necho line2'
+  q=\'
+  ble/test 'ble/builtin/history/.write out "$_ble_builtin_history_wskip" append; ble/test/history/rskip out' stdout=4
+  ble/test 'ble/bin/awk "END { print NR; }" out' stdout=8
+  ble/test 'ble/bin/awk "END { print; }" out' stdout="eval -- \$${q}echo multi\\necho line2${q}"
+
+  ble/test/rmdir
+)
+
+#------------------------------------------------------------------------------
+# ble/builtin/history/.initialize
+#
+#   rskip starts as the number of entries in HISTFILE.  It is clamped to the
+#   number of entries Bash has read from HISTFILE when the in-memory history
+#   is not truncated by HISTSIZE, so that entries appended by other sessions
+#   between Bash's startup and the lazy initialization are picked up by the
+#   next "history -n".  With a truncated in-memory history the clamp must not
+#   apply (it would re-read the file).
+
+(
+  ble/test/chdir || exit
+
+  ble/test '(ble/test/history/initialize-rskip 10 0 "" "")' stdout=10 \
+           '# no growth, unlimited'
+  ble/test '(ble/test/history/initialize-rskip 10 2 "" "")' stdout=10 \
+           '# growth by 2 entries is detected'
+  ble/test '(ble/test/history/initialize-rskip 10 2 ts "")' stdout=10 \
+           '# the same with timestamp lines (entries, not lines)'
+  ble/test '(ble/test/history/initialize-rskip 10 0 ts "")' stdout=10
+  ble/test '(ble/test/history/initialize-rskip 10 2 "" 10)' stdout=12 \
+           '# in-memory history full (HISTSIZE reached): no clamp'
+  ble/test '(ble/test/history/initialize-rskip 10 2 "" 5)' stdout=12 \
+           '# in-memory history truncated by HISTSIZE: no clamp'
+  ble/test '(ble/test/history/initialize-rskip 10 0 ts 5)' stdout=10
+  if ble/test/history/.check-session-entries; then
+    ble/test '(ble/test/history/initialize-rskip 10 0 ts "" 1)' stdout=10 \
+             '# an entry added in this session is not counted as read from HISTFILE'
+    ble/test '(ble/test/history/initialize-rskip 10 2 ts "" 1)' stdout=10 \
+             '# ... and does not hide growth'
+  fi
+
+  # the following "history -n" loads exactly the new entries
+  ble/test '(
+    ble/test/history/initialize-rskip 10 2 ts "" >/dev/null
+    ble/builtin/history/option:n
+    ble/test/history/rskip "$HISTFILE"; ble/test/history/count
+    ble/test/history/list | ble/bin/awk "NR > 10")' \
+    stdout=$'12\n12\necho cmd11\necho cmd12' \
+    '# history -n after growth'
+  ble/test '(
+    ble/test/history/initialize-rskip 10 2 ts 5 >/dev/null
+    ble/builtin/history/option:n
+    ble/test/history/rskip "$HISTFILE"; ble/test/history/count
+    ble/test/history/list | ble/bin/awk "NR > 3")' \
+    stdout=$'12\n5\necho cmd9\necho cmd10' \
+    '# history -n after growth with HISTSIZE truncation: nothing is re-read'
+
+  # entries added before the initialization are written by the next history -a
+  if ble/test/history/.check-session-entries; then
+    ble/test '(
+      ble/test/history/initialize-rskip 10 0 ts "" 1 >/dev/null
+      ble/builtin/history/.write "$HISTFILE" "$_ble_builtin_history_wskip" append
+      ble/test/history/rskip "$HISTFILE"; ble/builtin/history/.count-entries "$HISTFILE"; ble/util/print "$ret"
+      ble/bin/awk "END { print; }" "$HISTFILE")' \
+      stdout=$'11\n11\necho session1' \
+      '# entries collected by .initialize advance rskip when written'
+  fi
+
+  ble/test/rmdir
+)
+
+ble/test/end-section

--- a/src/history.sh
+++ b/src/history.sh
@@ -757,6 +757,7 @@ if ((_ble_bash>=30100)); then
       ble/util/print : >| "$tmpfile_base.sh"
     fi
   }
+
   function ble/history:bash/resolve-multiline/.is-HISTSIZE-unlimited {
     [[ ${HISTSIZE+set} ]] || return 1
 
@@ -766,9 +767,18 @@ if ((_ble_bash>=30100)); then
     # value in Bash <= 4.2.  In Bash >= 4.3, the interpretatiion of negative
     # numbers (in 32-bit representation) has been changed to mean the unlimited
     # history size.
-    ble/string#match "$HISTSIZE" '^[[:space:]]([-+]?[0-9]+)[[:space:]]*$' || return 0
+    # FIXME: Three typos have been fixed here.  The regex lacked "*" after the
+    # leading [[:space:]], so a plain number (e.g., HISTSIZE=500) never matched
+    # and was reported as unlimited; the negative check read an undefined
+    # variable "histize"; and the sign bit of the 32-bit representation is
+    # 0x80000000, not 0x10000000.  As a consequence, .load now really sets
+    # "local HISTSIZE=" for numeric values, as originally intended.  This has a
+    # visible effect for "readonly HISTSIZE=<n>": the assignment fails with
+    # "readonly variable" on every rebuild, where it used to be skipped by
+    # accident.  A "ble/is-readonly HISTSIZE" guard in .load would avoid that
+    ble/string#match "$HISTSIZE" '^[[:space:]]*([-+]?[0-9]+)[[:space:]]*$' || return 0
     local histsize=$((BASH_REMATCH[1]))
-    ((_ble_bash>=40300&&(histize&0x10000000)))
+    ((_ble_bash>=40300&&(histsize&0x80000000)))
   }
   function ble/history:bash/resolve-multiline/.load {
     local tmpfile_base=$_ble_base_run/$$.history.mlfix
@@ -944,6 +954,13 @@ if [[ ! ${_ble_builtin_history_initialized+set} ]]; then
   ##
   ## 以下の関数は各ファイルに関して何処まで読み取ったかを記録します。
   ##
+  ## Note: rskip is the number of entries of the file that have already been
+  ##   read into the history list (either by Bash on startup or by
+  ##   ble/builtin/history/.read).  It counts entries, not lines: a timestamp
+  ##   line (#<epoch>) belongs to the entry, and every other line is
+  ##   one entry, which is how .read loads the file.  This makes rskip
+  ##   consistent with wskip and with HISTSIZE and HISTFILESIZE counting
+  ##
   ## @fn ble/builtin/history/.get-rskip file
   ##   @param[in] file
   ##   @var[out] rskip
@@ -973,6 +990,53 @@ if [[ ! ${_ble_builtin_history_initialized+set} ]]; then
   }
 fi
 
+## @fn ble/builtin/history/.count-entries file
+##   Counts the entries in a file of the "history -w" format. Timestamp lines
+##   (#<epoch>) are not counted, and every other line counts as one entry.
+##   /^#[0-9]/ matches bash history behavior (#digit -> timestamp line)
+##   @var[out] ret
+function ble/builtin/history/.count-entries {
+  local file=$1
+  ble/util/assign ret 'ble/bin/awk '\''!/^#[0-9]/ { n++; } END { print n + 0; }'\'' "$file"'
+}
+
+## @fn ble/builtin/history/.is-HISTSIZE-reached count
+##   Checks whether Bash's in-memory history (the entries printed by "builtin
+##   history"), which currently holds "count" entries, has reached the limit
+##   given by HISTSIZE.  When this is the case, Bash may already have dropped
+##   the oldest entries, so "count" does not tell how many entries Bash has
+##   read from HISTFILE.
+##
+##   Bash applies the limit only when HISTSIZE holds an integer.  It parses the
+##   value with legal_number(), i.e., strtoimax() with trailing whitespace
+##   allowed: optional leading whitespace, an optional sign, decimal digits,
+##   optional trailing whitespace.  An unset or empty HISTSIZE removes the
+##   limit, and any other value (e.g., "5x" or "0x10") is ignored by Bash, which
+##   in practice also means no limit.  The value is therefore validated against
+##   that format before it is used in arithmetic; evaluating an arbitrary
+##   string with $((...)) would be wrong for such values and unsafe.
+##   @param[in] count
+function ble/builtin/history/.is-HISTSIZE-reached {
+  local count=$1
+  # HISTSIZE unset: unlimited
+  [[ ${HISTSIZE+set} ]] || return 1
+  # HISTSIZE empty or not a number: unlimited
+  ble/string#match "$HISTSIZE" '^[[:space:]]*([-+]?[0-9]+)[[:space:]]*$' || return 1
+  local histsize=$((BASH_REMATCH[1]))
+  if ((histsize<0)); then
+    # Note: A negative HISTSIZE means the unlimited size in Bash >= 4.3.  In
+    #   older versions it limits the in-memory history (Bash 3.2 keeps nothing),
+    #   so we conservatively treat it as truncated there.
+    ((_ble_bash<40300))
+  else
+    # Note: When the in-memory history is full, entries may already have been
+    #   dropped.  "Exactly full" cannot be distinguished from "truncated", so it
+    #   is treated as truncated, which only means that .initialize skips the
+    #   clamp of rskip.
+    ((count>=histsize))
+  fi
+}
+
 ## @fn ble/builtin/history/.initialize opts
 ##   @param[in] opts
 ##     skip0 ... Bash 初期化処理 (bashrc) を抜け出ていると判定できない状態で、
@@ -986,13 +1050,30 @@ function ble/builtin/history/.initialize {
   local histnew=$_ble_base_run/$$.history.new
   >| "$histnew"
 
+  local nsession=0
   if [[ $line ]]; then
     # Note: #D1126 ble.sh ロード前に追加された履歴項目があれば保存する。
     local histini=$_ble_base_run/$$.history.ini
-    local histapp=$_ble_base_run/$$.history.app
+    local -x histapp=$_ble_base_run/$$.history.app
     HISTTIMEFORMAT=1 builtin history -a "$histini"
     if [[ -s $histini ]]; then
-      ble/bin/sed '/^#\([0-9].*\)/{s//    0  __ble_time_\1__/;N;s/\n//;}' "$histini" >> "$histapp"
+      # Note: Convert the "history -w" format of histini (a "#<epoch>" line
+      #   followed by the command) to the "builtin history" format of histapp,
+      #   and count the entries added in this session (i.e., not read from
+      #   HISTFILE) on the way: one timestamp line per entry, while an entry
+      #   may span multiple lines.
+      ble/util/assign nsession 'ble/bin/awk '\''
+        BEGIN { histapp = ENVIRON["histapp"]; }
+        /^#[0-9]/ {
+          t++;
+          line = "    0  __ble_time_" substr($0, 2) "__";
+          if ((getline cmd) > 0) line = line cmd;
+          print line >> histapp;
+          next;
+        }
+        { c++; print $0 >> histapp; }
+        END { print (t ? t : c) + 0; }
+      '\'' "$histini"'
       >| "$histini"
     fi
   else
@@ -1000,12 +1081,27 @@ function ble/builtin/history/.initialize {
     ble/builtin/history/option:r
   fi
 
-  local histfile=${HISTFILE-} rskip=0
-  [[ -e $histfile ]] && ble/util/assign rskip 'ble/bin/wc -l "$histfile" 2>/dev/null'
-  ble/string#split-words rskip "$rskip"
+  # Note: rskip is the number of entries of HISTFILE that have already been
+  #   read into the history list.  Bash reads the whole file on startup, so this
+  #   is normally the number of entries in the file.
+  local histfile=${HISTFILE-} rskip=0 ret
+  [[ -s $histfile ]] && ble/builtin/history/.count-entries "$histfile" && rskip=$ret
   local min; ble/builtin/history/.get-min
   local max; ble/builtin/history/.get-max
-  ((max&&max-min+1<rskip&&(rskip=max-min+1)))
+  # Note: HISTFILE may have grown after Bash read it because this function is
+  #   called lazily and other sessions may append to HISTFILE in the meantime.
+  #   When the list is not truncated by HISTSIZE, Bash holds exactly the
+  #   entries read from HISTFILE plus the entries added in this session, so the
+  #   remaining entries in HISTFILE are new and should be picked up by the next
+  #   "history -n".  When the list is truncated by HISTSIZE, its size does not
+  #   tell how many entries have been read, and Bash has read the whole file
+  #   anyway, so rskip must not be clamped (that would re-read the file).
+  #   Both rskip and max-min+1 count entries, not lines; with HISTTIMEFORMAT
+  #   each entry occupies two lines in HISTFILE.
+  if ((max&&rskip)) && ! ble/builtin/history/.is-HISTSIZE-reached "$((max-min+1))"; then
+    local nread=$((max-min+1-nsession))
+    ((0<=nread&&nread<rskip)) && rskip=$nread
+  fi
   _ble_builtin_history_wskip=$max
   _ble_builtin_history_prevmax=$max
   ble/builtin/history/.set-rskip "$histfile" "$rskip"
@@ -1073,16 +1169,29 @@ function ble/builtin/history/.load-recent-entries {
   blehook/invoke history_change insert "$ocount" "$delta"
 }
 ## @fn ble/builtin/history/.read file [skip [fetch]]
+##   @param[in] file
+##   @param[in] skip
+##     The number of entries at the beginning of the file to skip.
+##   @param[in] fetch
 function ble/builtin/history/.read {
   local file=$1 skip=${2:-0} fetch=$3
   local -x histnew=$_ble_base_run/$$.history.new
   if [[ -s $file ]]; then
+    # Note: Entries are counted in the same way as .count-entries: a timestamp
+    #   line belongs to the following entry, and every other line is an entry.
     local awk_script='
-      BEGIN { histnew = ENVIRON["histnew"]; count = 0; }
-      NR <= skip { next; }
-      { print $0 >> histnew; count++; }
+      BEGIN { histnew = ENVIRON["histnew"]; count = 0; nentry = 0; }
+      /^#[0-9]/ {
+        if (nentry >= skip) print $0 >> histnew;
+        next;
+      }
+      {
+        if (nentry++ < skip) next;
+        print $0 >> histnew;
+        count++;
+      }
       END {
-        print "ble/builtin/history/.set-rskip \"$file\" " NR;
+        print "ble/builtin/history/.set-rskip \"$file\" " nentry;
         print "((_ble_builtin_history_histnew_count+=" count "))";
       }'
     ble/util/eval-stdout 'ble/bin/awk -v skip="$skip" "$awk_script" "$file"'
@@ -1090,11 +1199,11 @@ function ble/builtin/history/.read {
     ble/builtin/history/.set-rskip "$file" 0
   fi
   if [[ ! $fetch && -s $histnew ]]; then
-    local nline=$_ble_builtin_history_histnew_count
+    local nentry=$_ble_builtin_history_histnew_count
     ble/history:bash/resolve-multiline/readfile "$histnew"
     >| "$histnew"
     _ble_builtin_history_histnew_count=0
-    ble/builtin/history/.load-recent-entries "$nline"
+    ble/builtin/history/.load-recent-entries "$nentry"
     local max; ble/builtin/history/.get-max
     _ble_builtin_history_wskip=$max
     _ble_builtin_history_prevmax=$max
@@ -1130,16 +1239,18 @@ function ble/builtin/history/.write {
 
   if [[ :$opts: != *:fetch:* && -s $histapp ]]; then
     local apos=\'
-    < "$histapp" ble/bin/awk '
+    local awk_script='
       BEGIN {
         file = ENVIRON["file"];
         flag_timestamp = ENVIRON["flag_timestamp"];
         timestamp = "";
         mode = 0;
+        nentry = 0;
       }
       function flush_line() {
         if (!mode) return;
         mode = 0;
+        nentry++;
         if (text ~ /\n/) {
           gsub(/['"$apos"'\\]/, "\\\\&", text);
           gsub(/\n/, "\\n", text);
@@ -1173,11 +1284,24 @@ function ble/builtin/history/.write {
         sub(/^ *[0-9]+\*? +(__ble_time_[0-9]*__|\?\?|.+: invalid timestamp)?/, "", $0);
       }
       { text = text != "" ? text "\n" $0 : $0; }
-      END { flush_line(); }
+      END { flush_line(); print nentry; }
     '
-    ble/builtin/history/.add-rskip "$file" "$_ble_builtin_history_histapp_count"
+    # Note: The entries written to the file are now "read" entries, so rskip is
+    #   advanced by their number.  The awk counts them because histapp may also
+    #   contain the entries collected by .initialize, which are not counted in
+    #   _ble_builtin_history_histapp_count.  When the file is rewritten from
+    #   scratch (history -w), it contains exactly these entries.
+    local nentry
+    ble/util/assign nentry '< "$histapp" ble/bin/awk "$awk_script"'
+    if [[ :$opts: == *:append:* ]]; then
+      ble/builtin/history/.add-rskip "$file" "$nentry"
+    else
+      ble/builtin/history/.set-rskip "$file" "$nentry"
+    fi
     >| "$histapp"
     _ble_builtin_history_histapp_count=0
+  elif [[ :$opts: != *:append:* ]]; then
+    ble/builtin/history/.set-rskip "$file" 0
   fi
   _ble_builtin_history_wskip=$max
   _ble_builtin_history_prevmax=$max


### PR DESCRIPTION
When enabling HISTTIMEFORMAT this check clamped the history. This caused ble.sh to re-read half of the history on the first history search. Removing the clamps removes the issue.

Use `bleopt prompt_rps1='\q{history-index}/\q{history-percentile}'` to make it obserable

Before the fix: Open a new tab. Check number. Press search. Number goes up by 50% to 100% (depending on size due to clamp).
After fix: no additional entries.