### PR TITLE
history: keep the HISTFILE write position across multiline resolution

### DIFF
--- a/src/history.sh
+++ b/src/history.sh
@@ -768,7 +768,18 @@ if ((_ble_bash>=30100)); then
     ble/history:bash/resolve-multiline/.is-HISTSIZE-unlimited || local HISTSIZE=
 
     local HISTCONTROL= HISTIGNORE=
+    # Note: The rebuilt list is renumbered and may contain a different number
+    #   of entries, so keep the number of entries not yet written to HISTFILE.
+    local max unwritten=
+    if [[ $_ble_builtin_history_initialized ]]; then
+      ble/builtin/history/.get-max
+      ((unwritten=max-_ble_builtin_history_wskip))
+    fi
     source -- "$tmpfile_base.sh"
+    if [[ $unwritten ]]; then
+      ble/builtin/history/.get-max
+      ((_ble_builtin_history_wskip=max-unwritten,_ble_builtin_history_prevmax=max))
+    fi
     ble/history:bash/resolve-multiline/.cleanup
   }
 


### PR DESCRIPTION
And one more. this is a race.

ble.sh's multiline resolution rebuilds the bash history list (history -c and re-add), which renumbers it and can change the entry count, but the "written up to here" pointer (wskip/prevmax) isn't adjusted. The rebuild runs asynchronously and takes seconds on macOS, so it regularly finishes after the first command has been recorded, and the next history -a re-appends already written entries (here: the previous session's last entry and the first command). Keep the number of unwritten entries constant across the rebuild instead.