### PR TITLE
history: fix history-search forward off by one when used at end of history

### DIFF
--- a/src/edit.sh
+++ b/src/edit.sh
@@ -10262,7 +10262,7 @@ function ble-edit/nsearch/.search.fib {
     ble-edit/nsearch/.show-status.fib
     if [[ $opt_forward ]]; then
       local count; ble/history/get-count
-      ((_ble_edit_nsearch_index=count-1))
+      ((_ble_edit_nsearch_index=count))
     else
       ((_ble_edit_nsearch_index=0))
     fi


### PR DESCRIPTION
Not a bug in #721 but a new one i noticed during testing.

I bind my arrow keys to history-search. When at an empty line (or end of search) and pressing down (history-search-forward) it incorrectly sets `count-1`. the next up-press will skip the last entry.

steps to reproduce (with ble.sh at `~/project/ble.sh/out/ble.sh`:

```bash
tmp=$(mktemp -d)
cat > "$tmp/rc" <<EOF
[[ \$- == *i* ]] && source ~/project/ble.sh/out/ble.sh --attach=none
HISTFILE=$tmp/histtest
bind '"\e[A": history-search-backward hide-status:immediate-accept'
bind '"\e[B": history-search-forward hide-status:immediate-accept'
[[ ! \${BLE_VERSION-} ]] || ble-attach
EOF
bash --rcfile "$tmp/rc" -i
```
Add two commands
```bash
echo one
```
```bash
echo two
```

Tests on fresh setup:
Test 1: Press up -> echo two shows
Test 2: Press down then up -> echo one shows
Test 3: Press up -> echo two shows -> Press down twice then up -> echo one shows

With the fix applied all of them show echo two.
